### PR TITLE
Remove Button type check in form submit handler

### DIFF
--- a/packages/dymik-core/src/components/DymikForm.vue
+++ b/packages/dymik-core/src/components/DymikForm.vue
@@ -34,7 +34,7 @@ function onValueChanged(fieldName: string, value: any) {
 }
 
 async function onFieldClick(field: FormField, event: Event) {
-    if (field.type === 'Button' && field.props.type === 'submit') {
+    if (field.props?.type === 'submit') {
         const isValid = props.form.validate();
 
         if (!isValid) {


### PR DESCRIPTION
Replace `field.type === 'Button' && field.props.type === 'submit'` with
`field.props?.type === 'submit'` so any field with submit type can trigger
form submission regardless of component type.

https://claude.ai/code/session_01QtnTxArmsAVmMiia7YPzek